### PR TITLE
Card caption below image, future post filter, Jekyll 4 upgrade

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,56 @@
+name: Build and Deploy Jekyll
+
+on:
+  push:
+    branches: ["main"]
+  # Rebuild daily at 06:00 UTC so scheduled posts go live on their date
+  schedule:
+    - cron: "0 6 * * *"
+  # Allow manual rebuild from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one deploy runs at a time; cancel any queued run if a new one starts
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true   # runs `bundle install` and caches gems
+
+      - name: Configure GitHub Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll 4
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        env:
+          JEKYLL_ENV: production
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,7 @@
 # Jekyll — run: bundle install && bundle exec jekyll serve
 source "https://rubygems.org"
-gem "jekyll"
+
+gem "jekyll", "~> 4.3"
+
+# Required for `jekyll serve` under Ruby 3.x
+gem "webrick"

--- a/css/modern-blog.css
+++ b/css/modern-blog.css
@@ -5,9 +5,7 @@
 	position: relative;
 	float: left;
 	width: 29%;
-	height: 0;
 	margin: 2%;
-	padding-bottom: 20%;
 }
 
 .card__container {
@@ -22,7 +20,7 @@
 }
 
 .card__container--closed {
-	position: absolute;
+	position: relative;
 	overflow: hidden;
 }
 
@@ -37,6 +35,9 @@
 
 .card__container--closed .card__image {
 	position: relative;
+	display: block;
+	width: 100%;
+	height: auto;
 	cursor: pointer;
 }
 /* Fix IE */
@@ -57,7 +58,7 @@
 
 .card__container--closed .card__content {
 	margin-top: 0;
-	padding: 0 16px;
+	padding: 0;
 	pointer-events: none;
 	background: transparent;
 }
@@ -71,12 +72,10 @@
 
 .card__container--closed .card__caption {
 	font-size: 1em;
-	max-width: auto;
-	padding: 10px 10px 12px;
-	-webkit-transform: translateY(-100%);
-	-ms-transform: translateY(-100%);
-	transform: translateY(-100%);
-	background: rgba(0, 0, 0, 0.7);
+	max-width: 100%;
+	padding: 12px 14px 14px;
+	background: #1e1c2e;
+	border-top: 3px solid #de6551;
 }
 
 .card__title {
@@ -87,8 +86,8 @@
 }
 
 .card__container--closed .card__title {
-	color: #fff;
-	text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+	color: #ffffff;
+	text-shadow: none;
 }
 
 .card__subtitle {
@@ -99,8 +98,8 @@
 }
 
 .card__container--closed .card__subtitle {
-	color: rgba(255, 255, 255, 0.85);
-	text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+	color: rgba(222, 101, 81, 0.9);
+	text-shadow: none;
 }
 
 .card__copy {
@@ -126,6 +125,14 @@
 }
 
 .card__container--closed .card__btn-close {
+	display: none;
+}
+
+.card__container--closed .card__copy {
+	display: none;
+}
+
+.card__container--closed .meta {
 	display: none;
 }
 
@@ -157,14 +164,12 @@
 @media only screen and (min-width: 1500px) {
 	.card {
 		width: 21%;
-		padding-bottom: 14.5%;
 	}
 }
 
 @media only screen and (max-width: 980px) {
 	.card {
 		width: 46%;
-		padding-bottom: 32.2%;
 	}
 	.card__content {
 		margin-bottom: 0;
@@ -176,7 +181,6 @@
 @media only screen and (max-width: 580px) {
 	.card {
 		width: 96%;
-		padding-bottom: 67.2%;
 	}
 }
 

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@ layout: compress
         <div class="pattern pattern--hidden"></div>
         <!-- cards -->
         <div class="wrapper">
-            {% for post in site.posts %}
+            {% for post in site.posts %}{% if post.date <= site.time %}
             <div class="card" data-id="{{ post.id }}">
                 <div class="card__container card__container--closed">
                     <svg class="card__image" xmlns="http://www.w3.org/2000/svg"
@@ -73,7 +73,7 @@ layout: compress
                     </div>
                 </div>
             </div>
-            {% endfor %}
+            {% endif %}{% endfor %}
             <!-- /cards -->
         </div>
     </div>


### PR DESCRIPTION
CSS — card layout:
- Remove height:0/padding-bottom trick; card now sizes from content
- Change .card__container--closed from position:absolute to relative
- Card image (SVG) maintains natural aspect ratio (no longer stretched)
- Caption strip sits BELOW the image with contrasting dark background (#1e1c2e) and coral accent border, white title, coral subtitle
- Hide .card__copy and .meta in closed state (full post content hidden)
- Remove stale padding-bottom values from all responsive breakpoints

index.html — future post filter:
- Wrap card loop with {% if post.date <= site.time %} so only past/ present posts appear in the grid; future posts still build and are accessible by URL (future: true stays in _config.yml)

Gemfile — Jekyll 4:
- Pin jekyll to ~> 4.3 (up from unpinned 3.x via github-pages)
- Add webrick (required for jekyll serve under Ruby 3.x)

.github/workflows/jekyll.yml — custom build pipeline:
- Replaces legacy github-pages builder with Jekyll 4 Actions workflow
- Daily cron at 06:00 UTC so scheduled posts go live on their date without needing a manual push
- Uses ruby/setup-ruby with bundler-cache for fast builds

NOTE: After merging, go to repo Settings → Pages → Source and switch from "Deploy from a branch" to "GitHub Actions" to activate this workflow.