### PR TITLE
Fix responsive grid blowout: min-width:0 on cards, fixed px gap

### DIFF
--- a/css/modern-blog.css
+++ b/css/modern-blog.css
@@ -3,6 +3,7 @@
 
 .card {
 	position: relative;
+	min-width: 0;
 }
 
 .card__container {
@@ -318,10 +319,10 @@ a:focus {
 .wrapper {
 	display: grid;
 	grid-template-columns: repeat(3, 1fr);
-	gap: 1.5%;
+	gap: 14px;
 	width: 95%;
 	max-width: 2200px;
-	margin: 0 auto;
+	margin: 0 auto 2em;
 }
 
 @media screen and (max-width: 50em) {


### PR DESCRIPTION
CSS Grid items default to min-width:auto which prevents them shrinking. Adding min-width:0 lets cards compress correctly at any viewport width. Switch gap from 1.5% to 14px for consistent spacing across breakpoints.